### PR TITLE
Fix for Windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,11 @@ package:
 source:
   url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.xz
   sha256: {{ sha256 }}
+  patches:
+    - mingw.patch  # [win]
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipe/mingw.patch
+++ b/recipe/mingw.patch
@@ -1,0 +1,15 @@
+diff --git a/Xtrans.h b/Xtrans.h
+index 8cf0daf..77af5ed 100644
+--- a/Xtrans.h
++++ b/Xtrans.h
+@@ -56,6 +56,10 @@ from The Open Group.
+ 
+ #ifndef WIN32
+ #include <sys/socket.h>
++#else
++/* conda-forge: nonstandard includes needed for struct addrinfo */
++#include <X11/Xwinsock.h>
++#include <ws2tcpip.h>
+ #endif
+ 
+ #ifdef __clang__


### PR DESCRIPTION
Users of this library will need `struct sockaddr`, but on MinGW we need to include some extra headers to get it.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
